### PR TITLE
Implements digits sanitizer

### DIFF
--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -110,6 +110,16 @@ module OStruct
           sanitize(field) { |value| value.strip }
         end
       end
+
+      # Removes any non-digit character from the values of the given fields
+      #
+      # @param [Array<Symbol>] fields list of fields to be sanitized
+      #
+      def digits(*fields)
+        fields.each do |field|
+          sanitize(field) { |value| value.to_s.gsub(/[^0-9]/, '') }
+        end
+      end
     end
   end
 end

--- a/lib/ostruct/sanitizer/version.rb
+++ b/lib/ostruct/sanitizer/version.rb
@@ -1,5 +1,5 @@
 module OStruct
   module Sanitizer
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -7,4 +7,5 @@ class User < OpenStruct
   truncate :first_name, :last_name, length: 10
   drop_punctuation :city, :country
   strip :email, :phone
+  digits :ssn, :cell_phone
 end

--- a/spec/ostruct/sanitizer_spec.rb
+++ b/spec/ostruct/sanitizer_spec.rb
@@ -87,4 +87,27 @@ describe OStruct::Sanitizer do
       expect(user.phone).to be nil
     end
   end
+
+  describe "#digits" do
+    let(:user) do
+      User.new(
+        ssn: "111-11-1111",
+        cell_phone: "+1-541-000-0000",
+      )
+    end
+
+    it "keeps only digits from ssn field" do
+      expect(user.ssn).to eq "111111111"
+    end
+
+    it "keeps only digits from cell_phone field" do
+      expect(user.cell_phone).to eq "15410000000"
+    end
+
+    it "does not sanitize if value is nil" do
+      user = User.new ssn: nil, cell_phone: nil
+      expect(user.ssn).to be nil
+      expect(user.cell_phone).to be nil
+    end
+  end
 end


### PR DESCRIPTION
Useful for removing non-digits characters from fields like `SSN`, `phone_number`.

Example:

```
class Person < OpenStruct
  include OStruct::Sanitizer

  digits :ssn, :phone_number
end

person = Person.new ssn: "111-11-1111", phone_number: "+1-111-111-1111"
person.ssn
=> 111111111
person.phone_number
=> 11111111111
```

