### PR TITLE
Add strip_whitespaces option to truncate sanitizer

### DIFF
--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -84,10 +84,12 @@ module OStruct
       #
       # @param [Array<Symbol>] a list of field names to be sanitized
       # @param [Integer] length the amount to truncate the field's value to
+      # @param [Boolean] strip_whitespaces whether or not to strip whitespaces
       #
-      def truncate(*fields, length:)
+      def truncate(*fields, length:, strip_whitespaces: true)
         fields.each do |field|
           sanitize(field) { |value| value[0...length] }
+          strip(field) if strip_whitespaces
         end
       end
 

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -5,6 +5,7 @@ class User < OpenStruct
   include OStruct::Sanitizer
 
   truncate :first_name, :last_name, length: 10
+  truncate :middle_name, length: 5, strip_whitespaces: false
   drop_punctuation :city, :country
   strip :email, :phone
   digits :ssn, :cell_phone

--- a/spec/ostruct/sanitizer_spec.rb
+++ b/spec/ostruct/sanitizer_spec.rb
@@ -22,17 +22,20 @@ describe OStruct::Sanitizer do
       User.new(
         first_name: "first name longer than 10 characters",
         last_name: "last name longer than 10 characters",
+        middle_name: "Rose ",
       )
     end
 
     it "truncates user's first name to 10 characters" do
-      expect(user.first_name.length).to be 10
       expect(user.first_name).to eq "first name"
     end
 
     it "truncates user's last name to 10 characters" do
-      expect(user.last_name.length).to be 10
-      expect(user.last_name).to eq "last name "
+      expect(user.last_name).to eq "last name"
+    end
+
+    it "truncates user's middle name without stipping whitespaces" do
+      expect(user.middle_name).to eq "Rose "
     end
 
     it "does not sanitize if value is nil" do


### PR DESCRIPTION
Add support for stripping whitespaces after truncation is performed.

Example:

By default whitespaces are stripped out.

```ruby
class User < OpenStruct
  include OStruct::Sanitizer
  truncate :middle_name, length: 5
end

user = User.new middle_name: " Rose "
user.middle_name
=> "Rose"
```

That behavior may be disabled:

```ruby
class User < OpenStruct
  include OStruct::Sanitizer
  truncate :middle_name, length: 5, strip_whitespaces: false
end

user = User.new middle_name: " Rose "
user.middle_name
=> " Rose "
```