### PR TITLE
Use OStruct::Sanitizer module name in error message

### DIFF
--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -19,7 +19,7 @@ module OStruct
   module Sanitizer
     def self.included(base)
       unless base.ancestors.include? OpenStruct
-        raise "OpenStructSanitizer can only be used within OpenStruct classes."
+        raise "#{self.name} can only be used within OpenStruct classes"
       end
 
       base.extend ClassMethods

--- a/spec/ostruct/sanitizer_spec.rb
+++ b/spec/ostruct/sanitizer_spec.rb
@@ -13,7 +13,7 @@ describe OStruct::Sanitizer do
         end
       }
 
-      expect(define_invalid_usage).to raise_error
+      expect(define_invalid_usage).to raise_error "#{OStruct::Sanitizer.name} can only be used within OpenStruct classes"
     end
   end
 


### PR DESCRIPTION
Remove hardcoded (and incorrect) module name from error message when including `OStruct::Sanitizer` in a non `OpenStruct` class.