### PR TITLE
Strip whitespaces before and after truncating

### DIFF
--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -89,6 +89,7 @@ module OStruct
       # @param [Boolean] strip_whitespaces whether or not to strip whitespaces
       #
       def truncate(*fields, length:, strip_whitespaces: true)
+        strip(*fields) if strip_whitespaces
         sanitize(*fields) { |value| value[0...length] }
         strip(*fields) if strip_whitespaces
       end

--- a/spec/fixtures/user.rb
+++ b/spec/fixtures/user.rb
@@ -5,7 +5,7 @@ class User < OpenStruct
   include OStruct::Sanitizer
 
   truncate :first_name, :last_name, length: 10
-  truncate :middle_name, length: 5, strip_whitespaces: false
+  truncate :middle_name, length: 3, strip_whitespaces: false
   drop_punctuation :city, :country
   strip :email, :phone
   digits :ssn, :cell_phone

--- a/spec/ostruct/sanitizer_spec.rb
+++ b/spec/ostruct/sanitizer_spec.rb
@@ -20,9 +20,9 @@ describe OStruct::Sanitizer do
   describe "#truncate" do
     let(:user) do
       User.new(
-        first_name: "first name longer than 10 characters",
-        last_name: "last name longer than 10 characters",
-        middle_name: "Rose ",
+        first_name: " first name longer than 10 characters",
+        last_name: " last name longer than 10 characters",
+        middle_name: " Rose ",
       )
     end
 
@@ -35,7 +35,7 @@ describe OStruct::Sanitizer do
     end
 
     it "truncates user's middle name without stipping whitespaces" do
-      expect(user.middle_name).to eq "Rose "
+      expect(user.middle_name).to eq " Ro"
     end
 
     it "does not sanitize if value is nil" do


### PR DESCRIPTION
This handles cases where the value has leading whitespaces and stripping them out ensures that more useful data is yielded.