### PR TITLE
Ruby >= 2.3.x Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.4
+  - 2.3.3
+  - ruby-head
 before_install: gem install bundler -v 1.13.6

--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -28,7 +28,7 @@ module OStruct
     # Initializes the OpenStruct applying any registered sanitization rules
     #
     def initialize(attrs = {})
-      super
+      super nil
       attrs.each_pair do |field, value|
         self[field] = value
       end

--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -30,30 +30,42 @@ module OStruct
     def initialize(attrs = {})
       super
       attrs.each_pair do |field, value|
-        self.send("#{field}=", value)
+        send("#{field}=", value)
       end
     end
 
-    # Overrides ostruct member definition applying sanitization rules when needed
+    # Creates a setter method for the corresponding field which applies any
+    # existing sanitization rules
     #
-    # @param [#to_sym] field the name of the field being defined
-    # @return [Symbol] the name of the defined field
+    # @param [Symbol] method the missing method
+    # @param [Array<Any>] args the method's arguments list
     #
-    def new_ostruct_member(field)
-      field = field.to_sym
-      unless respond_to?(field)
-        define_singleton_method(field) { modifiable[field] }
-        define_singleton_method("#{field}=") do |value|
-          modifiable[field] = sanitize(field, value)
-        end
+    def method_missing(method, *args)
+      super method, *args
+      if field = setter?(method)
+        # override setter logic to apply any existing sanitization rules before
+        # assigning the new value to the field
+        override_setter_for(field) if sanitize?(field)
+        # uses the newly created setter to set the field's value and apply any
+        # existing sanitization rules
+        send(method, args[0])
       end
-      field
     end
 
     private
 
+    def setter?(method)
+      method[/.*(?==\z)/m].to_s.to_sym
+    end
+
+    def override_setter_for(field)
+      define_singleton_method("#{field}=") do |value|
+        modifiable[field] = sanitize(field, value)
+      end
+    end
+
     def sanitize(field, value)
-      return value if value.nil? || !sanitize?(field)
+      return value if value.nil?
       self.class.sanitizers[field].reduce(value) do |current_value, sanitizer|
         sanitizer.call(current_value)
       end

--- a/lib/ostruct/sanitizer/version.rb
+++ b/lib/ostruct/sanitizer/version.rb
@@ -1,5 +1,5 @@
 module OStruct
   module Sanitizer
-    VERSION = "0.4.1"
+    VERSION = "0.5.1"
   end
 end

--- a/ostruct-sanitizer.gemspec
+++ b/ostruct-sanitizer.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "byebug"
 end

--- a/spec/ostruct/sanitizer_spec.rb
+++ b/spec/ostruct/sanitizer_spec.rb
@@ -134,4 +134,32 @@ describe OStruct::Sanitizer do
       expect(user.cell_phone).to be nil
     end
   end
+
+  describe "#sanitize" do
+    class User < OpenStruct
+      include OStruct::Sanitizer
+      sanitize "my ssn" do |value|
+        value.to_s.gsub(/[^0-9]/, '')
+      end
+    end
+
+    context "hash syntax" do
+      it "applies sanitization rules using string as key" do
+        user = User.new
+        user["my ssn"] = "111-11-1111"
+        expect(user["my ssn"]).to eq "111111111"
+      end
+
+      it "applies sanitization rules using symbol as key" do
+        user = User.new
+        user[:"my ssn"] = "111-11-1111"
+        expect(user["my ssn"]).to eq "111111111"
+      end
+
+      it "applies sanitization rules using string as key in the constructor" do
+        user = User.new "my ssn" => "111-11-1111"
+        expect(user[:"my ssn"]).to eq "111111111"
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
+require "byebug"
 require "ostruct/sanitizer"
+
 Dir['spec/fixtures/*.rb'].each do |f|
   require_relative "../#{f}"
 end


### PR DESCRIPTION
The OpenStruct internals [was changed](https://github.com/ruby/ruby/commit/7c89ca5431c370496e0f1ee3761781e6d74e57b4#diff-f0ac5119f74bfda273347c9925e910d7) quite a bit on newer (>= 2.3.x) versions of Ruby. This PR allows the gem to work across different Ruby versions.