### PR TITLE
Upgrades ruby version. Bumped gem version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5"
-          - "2.6"
+          - "2.7"
+          - "3.0"
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
       matrix:
         ruby:
           - "2.7"
-          - "3.0"
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: ruby
 rvm:
   - 2.2.4
   - 2.3.3
+  - 2.7.3
   - ruby-head
-before_install: gem install bundler -v 1.13.6
+before_install: gem install bundler -v 2.2.25

--- a/lib/ostruct/sanitizer.rb
+++ b/lib/ostruct/sanitizer.rb
@@ -73,7 +73,7 @@ module OStruct
 
     def override_setter_for(field)
       define_singleton_method("#{field}=") do |value|
-        modifiable[field] = sanitize(field, value)
+        modifiable?[field] = sanitize(field, value)
       end
     end
 

--- a/lib/ostruct/sanitizer/version.rb
+++ b/lib/ostruct/sanitizer/version.rb
@@ -1,5 +1,5 @@
 module OStruct
   module Sanitizer
-    VERSION = "0.5.1"
+    VERSION = "0.6.0"
   end
 end

--- a/ostruct-sanitizer.gemspec
+++ b/ostruct-sanitizer.gemspec
@@ -21,7 +21,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.required_ruby_version = '>= 2.7'
+
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
In the way of upgrading Nitro to Ruby 2.7, this gem needed an upgrade to be compatible with Ruby 2.7
This change might break retrocompatibility, so we are bumping the minor version.

I'd need comments on the best way to achieve this, so that's why this PR should be considered a RFC with potential to be merged if everything looks OK.

Things I might have done wrong:
1. Update bundler at the same time, but it looked right to have a newer version
2. Update the minor instead of the major semver
3. There is no changelog to upgrade, but that might be useful
4. Add a minor spec for ruby version at 2.7